### PR TITLE
Fixes for MSYS2 with GCC 6.3 toolchian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,9 @@ add_executable(xmr-stak-amd
 )
 set(EXECUTABLE_OUTPUT_PATH "bin")
 target_link_libraries(xmr-stak-amd ${LIBS} xmr-stak-amd-c)
-
+if(${MINGW})
+    target_link_libraries(xmr-stak-amd ws2_32)
+endif()
 ################################################################################
 # Install
 ################################################################################

--- a/crypto/cryptonight_aesni.h
+++ b/crypto/cryptonight_aesni.h
@@ -19,7 +19,7 @@
 #include <memory.h>
 #include <stdio.h>
 
-#ifdef __GNUC__
+#if defined __GNUC__ && !defined _WIN32
 #include <x86intrin.h>
 static inline uint64_t _umul128(uint64_t a, uint64_t b, uint64_t* hi)
 {

--- a/minethd.cpp
+++ b/minethd.cpp
@@ -32,7 +32,7 @@
 
 void thd_setaffinity(std::thread::native_handle_type h, uint64_t cpu_id)
 {
-	SetThreadAffinityMask(h, 1ULL << cpu_id);
+	SetThreadAffinityMask((HANDLE)h, 1 << cpu_id);
 }
 
 #else


### PR DESCRIPTION
These are minor compatibility fixes to support current MSYS2 + GCC 6.3 environment. Tested with `cmake -G"MSYS Makefiles" .` generator.