### PR TITLE
add OpenCl 1.2 support

### DIFF
--- a/amd_gpu/gpu.c
+++ b/amd_gpu/gpu.c
@@ -163,10 +163,12 @@ const char* err_to_str(cl_int ret)
 		return "CL_INVALID_LINKER_OPTIONS";
 	case CL_INVALID_DEVICE_PARTITION_COUNT:
 		return "CL_INVALID_DEVICE_PARTITION_COUNT";
+#ifdef CL_VERSION_2_0
 	case CL_INVALID_PIPE_SIZE:
 		return "CL_INVALID_PIPE_SIZE";
 	case CL_INVALID_DEVICE_QUEUE:
 		return "CL_INVALID_DEVICE_QUEUE";
+#endif
 	default:
 		return "UNKNOWN_ERROR";
 	}


### PR DESCRIPTION
guard unknown defined from OpenCl 2.X

After this pull request  #10 needs to be rebased to resolve conflicts. #10 solves the OpenCL version issu with a guard for apple but `CL_INVALID_PIPE_SIZE` and `CL_INVALID_DEVICE_QUEUE` are platform independent and introduced with OpenCl 2.0.