### PR TITLE
Mac support

### DIFF
--- a/amd_gpu/gpu.h
+++ b/amd_gpu/gpu.h
@@ -1,6 +1,11 @@
 #pragma once
 
+#if defined(__APPLE__)
+#include <OpenCL/cl.h>
+#else
 #include <CL/cl.h>
+#endif
+
 #include <stdint.h>
 
 #define ERR_SUCCESS (0)

--- a/minethd.cpp
+++ b/minethd.cpp
@@ -48,7 +48,7 @@ void thd_setaffinity(std::thread::native_handle_type h, uint64_t cpu_id)
 {
 #if defined(__APPLE__)
 	thread_port_t mach_thread;
-	thread_affinity_policy_data_t policy = { cpu_id };
+	thread_affinity_policy_data_t policy = { (int)cpu_id };
 	mach_thread = pthread_mach_thread_np(h);
 	thread_policy_set(mach_thread, THREAD_AFFINITY_POLICY, (thread_policy_t)&policy, 1);
 #else

--- a/opencl/cryptonight.cl
+++ b/opencl/cryptonight.cl
@@ -16,7 +16,6 @@
 #ifdef cl_amd_media_ops
 #pragma OPENCL EXTENSION cl_amd_media_ops : enable
 #else
-#pragma "Emulating amd_bitalign"
 // taken from https://github.com/Bdot42/mfakto/blob/master/src/common.cl
 // we should define something for bitalign() ...
 //     Build-in Function
@@ -30,15 +29,19 @@
 #ifdef cl_amd_media_ops2
 #pragma OPENCL EXTENSION cl_amd_media_ops2 : enable
 #else
-#pragma "Emulating amd_bfe"
-int amd_bfe(uint2 src0, uint2 src1, uint2 src2) 
+inline int amd_bfe(const uint2 src0, const uint2 src1, const uint2 src2)
 {
 	int offset = src1.s0 & 31; 
-	int width = src2.s0 & 31; 
-	if ( width == 0 ) 
-		return 0;
-	if ( (offset + width) < 32 ) 
-		return (src0.s0 << (32 - offset - width)) >> (32 - width);
+	int width = src2.s0 & 31;
+        /* remove check for edge case, this function is always called with
+         * `width==8`
+         * @code
+         *   if ( width == 0 )
+         *      return 0;
+         * @endcode
+         */
+        if ( (offset + width) < 32 )
+	        return (src0.s0 << (32 - offset - width)) >> (32 - width);
 
 	return src0.s0 >> offset;
 }

--- a/opencl/cryptonight.cl
+++ b/opencl/cryptonight.cl
@@ -16,34 +16,59 @@
 #ifdef cl_amd_media_ops
 #pragma OPENCL EXTENSION cl_amd_media_ops : enable
 #else
-// taken from https://github.com/Bdot42/mfakto/blob/master/src/common.cl
-// we should define something for bitalign() ...
-//     Build-in Function
-//      uintn  amd_bitalign (uintn src0, uintn src1, uintn src2)
-//    Description
-//      dst.s0 =  (uint) (((((long)src0.s0) << 32) | (long)src1.s0) >> (src2.s0 & 31))
-//      similar operation applied to other components of the vectors.
-#define amd_bitalign(src0, src1, src2) (src0  << (32-src2)) | (src1 >> src2)
+/* taken from https://www.khronos.org/registry/OpenCL/extensions/amd/cl_amd_media_ops.txt
+ * Build-in Function
+ *     uintn  amd_bitalign (uintn src0, uintn src1, uintn src2)
+ *   Description
+ *     dst.s0 =  (uint) (((((long)src0.s0) << 32) | (long)src1.s0) >> (src2.s0 & 31))
+ *     similar operation applied to other components of the vectors.
+ *
+ * The implemented function is modified because the last is in our case always a scalar.
+ * We can ignore the bitwise AND operation.
+ */
+inline uint2 amd_bitalign( const uint2 src0, const uint2 src1, const uint src2)
+{
+	uint2 result;
+	result.s0 =  (uint) (((((long)src0.s0) << 32) | (long)src1.s0) >> (src2));
+	result.s1 =  (uint) (((((long)src0.s1) << 32) | (long)src1.s1) >> (src2));
+	return result;
+}
 #endif
 
 #ifdef cl_amd_media_ops2
 #pragma OPENCL EXTENSION cl_amd_media_ops2 : enable
 #else
-inline int amd_bfe(const uint2 src0, const uint2 src1, const uint2 src2)
+/* taken from: https://www.khronos.org/registry/OpenCL/extensions/amd/cl_amd_media_ops2.txt
+ *     Built-in Function:
+ *     uintn amd_bfe (uintn src0, uintn src1, uintn src2)
+ *   Description
+ *     NOTE: operator >> below represent logical right shift
+ *     offset = src1.s0 & 31;
+ *     width = src2.s0 & 31;
+ *     if width = 0
+ *         dst.s0 = 0;
+ *     else if (offset + width) < 32
+ *         dst.s0 = (src0.s0 << (32 - offset - width)) >> (32 - width);
+ *     else
+ *         dst.s0 = src0.s0 >> offset;
+ *     similar operation applied to other components of the vectors
+ */
+inline int amd_bfe(const uint src0, const uint offset, const uint width)
 {
-	int offset = src1.s0 & 31; 
-	int width = src2.s0 & 31;
-        /* remove check for edge case, this function is always called with
-         * `width==8`
-         * @code
-         *   if ( width == 0 )
-         *      return 0;
-         * @endcode
-         */
-        if ( (offset + width) < 32 )
-	        return (src0.s0 << (32 - offset - width)) >> (32 - width);
+	/* casts are removed because we can implement everything as uint
+	 * int offset = src1;
+	 * int width = src2;
+	 * remove check for edge case, this function is always called with
+	 * `width==8`
+	 * @code
+	 *   if ( width == 0 )
+	 *      return 0;
+	 * @endcode
+	 */
+	if ( (offset + width) < 32u )
+		return (src0 << (32u - offset - width)) >> (32u - width);
 
-	return src0.s0 >> offset;
+	return src0 >> offset;
 }
 #endif
 


### PR DESCRIPTION
This pull requst integrate the changes of #10
 
## Changes
- include `OpenCL/cl.j` on Mac
- add option to emulate `amd_bfe` and `amd_bitalign`

## My changes on top of kth5's pull requst
- remove the not existent pragma `#pragma "Emulation *"`
- optimize `amd_bfe` (remove check for the edge case)

## Tests
- [x] runtime test linux (native amd intrinsics)
- [x] runtime test linux (emulated amd bfe/bit_align)
- [x] @kth5 Mac test
- [x] please do not merge before #39 this branch needs a rebase