### PR TITLE
add missing include

### DIFF
--- a/amd_gpu/gpu.c
+++ b/amd_gpu/gpu.c
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <math.h>
 
 #ifdef _WIN32
 #include <windows.h>


### PR DESCRIPTION
add include `math.h`

bug seen in #32