### PR TITLE
Randomly choose from all available IP addresses

### DIFF
--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -36,6 +36,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <ctime>
+
 #ifndef CONF_NO_TLS
 #include <openssl/ssl.h>
 #include <openssl/err.h>
@@ -68,6 +70,8 @@ int main(int argc, char *argv[])
 	SSL_load_error_strings();
 	OpenSSL_add_all_digests();
 #endif
+
+	std::srand(std::time(0));
 
 	const char* sFilename = "config.txt";
 	bool benchmark_mode = false;

--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -36,7 +36,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <ctime>
+#include <time.h>
 
 #ifndef CONF_NO_TLS
 #include <openssl/ssl.h>
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
 	OpenSSL_add_all_digests();
 #endif
 
-	std::srand(std::time(0));
+	srand(time(0));
 
 	const char* sFilename = "config.txt";
 	bool benchmark_mode = false;

--- a/socket.cpp
+++ b/socket.cpp
@@ -75,33 +75,34 @@ bool plain_socket::set_hostname(const char* sAddr)
 		return pCallback->set_socket_error_strerr("CONNECT error: GetAddrInfo: ", err);
 
 	addrinfo *ptr = pAddrRoot;
-	addrinfo *ipv4 = nullptr, *ipv6 = nullptr;
+	std::vector<addrinfo*> ipv4;
+	std::vector<addrinfo*> ipv6;
 
 	while (ptr != nullptr)
 	{
 		if (ptr->ai_family == AF_INET)
-			ipv4 = ptr;
+			ipv4.push_back(ptr);
 		if (ptr->ai_family == AF_INET6)
-			ipv6 = ptr;
+			ipv6.push_back(ptr);
 		ptr = ptr->ai_next;
 	}
 
-	if (ipv4 == nullptr && ipv6 == nullptr)
+	if (ipv4.empty() && ipv6.empty())
 	{
 		freeaddrinfo(pAddrRoot);
 		pAddrRoot = nullptr;
 		return pCallback->set_socket_error("CONNECT error: I found some DNS records but no IPv4 or IPv6 addresses.");
 	}
-	else if (ipv4 != nullptr && ipv6 == nullptr)
-		pSockAddr = ipv4;
-	else if (ipv4 == nullptr && ipv6 != nullptr)
-		pSockAddr = ipv6;
-	else if (ipv4 != nullptr && ipv6 != nullptr)
+	else if (!ipv4.empty() && ipv6.empty())
+		pSockAddr = ipv4[rand() % ipv4.size()];
+	else if (ipv4.empty() && !ipv6.empty())
+		pSockAddr = ipv6[rand() % ipv6.size()];
+	else if (!ipv4.empty() && !ipv6.empty())
 	{
 		if(jconf::inst()->PreferIpv4())
-			pSockAddr = ipv4;
+			pSockAddr = ipv4[rand() % ipv4.size()];
 		else
-			pSockAddr = ipv6;
+			pSockAddr = ipv6[rand() % ipv6.size()];
 	}
 
 	hSocket = socket(pSockAddr->ai_family, pSockAddr->ai_socktype, pSockAddr->ai_protocol);


### PR DESCRIPTION
This is to avoid getting stuck on the same IP which doesn't work for whatever reason.

pool.supportxmr.com uses DNS for load balancing, and it had issues with xmr-stak miners when one of the servers went down and all xmr-stak miners that were on that server didn't switch to the other working server. This change fixes the bug.