### PR TITLE
Updated README.md to include Fedora instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,32 @@ http://support.amd.com/en-us/kb-articles/Pages/AMDGPU-PRO-Install.aspx
     make
 ```
 
+#### Usage on Linux (Fedora-based distros)
+
+**Download the CentOS 7 AMD Driver**
+
+http://support.amd.com/en-us/kb-articles/Pages/AMDGPU-PRO-Install.aspx
+
+Do not install the full AMDGPU-PRO driver, as Fedora has a newer version of X11 than the driver works with, instead do the following on the AMDGPU-PRO Installer.
+
+Press Y when it prompts to install OpenCL related packages. Ignore the DKMS errors.
+```
+sudo amdgpu-pro-install --compute
+```
+
+```
+    sudo dnf install ocl-icd-devel libmicrohttpd-devel openssl-devel cmake gcc-c++
+    cmake .
+    make
+```
+
+To run the miner with the newly installed OpenCL libraries, create a shell script in the bin folder containing the following
+
+```
+#!/bin/bash
+LD_LIBRARY_PATH=/usr/lib64/amdgpu-pro-opencl/ ./xmr-stak-amd
+```
+
 GCC version 5.1 or higher is required for full C++11 support. CMake release compile scripts, as well as CodeBlocks build environment for debug builds is included.
 
 #### Mining performance 


### PR DESCRIPTION
Updated README.md to include instructions for compiling and running miner on Fedora.

Since the proprietary driver does not run on Fedora, you have to set tell the miner to only use the proprietary OpenCL libraries.

More detailed information on this is available on my blog:
https://blog.orcadian.net/2017/07/28/using-the-proprietary-amdgpu-pro-opencl-libraries-without-installing-the-proprietary-driver-on-fedora-25-26/