### PR TITLE
Windows Compilation - in response to fireice-uk/xmr-stak-amd#72

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,11 +61,31 @@ set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
 
 option(MICROHTTPD_ENABLE "Enable or disable the requirement of microhttp (http deamon)" ON)
 if(MICROHTTPD_ENABLE)
-    find_library(MHTD NAMES microhttpd)
+    find_path(MTHD_INCLUDE_DIR
+        NAMES
+            microhttpd.h
+        PATHS
+            /opt/local
+            /usr/local
+            /usr
+            ENV "PROGRAMFILES(X86)"
+            ENV "HWLOC_ROOT"
+        PATH_SUFFIXES
+            include)
+
+    find_library(MHTD
+        NAMES
+            microhttpd
+            libmicrohttpd.lib
+        PATHS
+            ENV "MICROHTTPD_ROOT"
+        PATH_SUFFIXES
+            lib)
     if("${MHTD}" STREQUAL "MHTD-NOTFOUND")
         message(FATAL_ERROR "microhttpd NOT found: use `-DMICROHTTPD_ENABLE=OFF` to build without http deamon support")
     else()
         set(LIBS ${LIBS} ${MHTD})
+        include_directories(AFTER ${MTHD_INCLUDE_DIR})
     endif()
 else()
     add_definitions("-DCONF_NO_HTTPD")

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ XMR-Stak is a universal Stratum pool miner. This is the AMD GPU-mining version; 
 
 The hashrate shown above was generated on a non-modded, non-overclocked RX 480.
 
-#### Usage on Windows 
+#### Usage on Windows
 
-1) Edit the config.txt file to enter your pool login and password. 
-2) Double click the exe file. 
+1) Edit the config.txt file to enter your pool login and password.
+2) Double click the exe file.
 
 XMR-Stak should compile on any C++11 compliant compiler. Windows compiler is assumed to be MSVC 2015 CE. MSVC build environment is not vendored.
 ```
@@ -100,7 +100,11 @@ LD_LIBRARY_PATH=/usr/lib64/amdgpu-pro-opencl/ ./xmr-stak-amd
 
 GCC version 5.1 or higher is required for full C++11 support. CMake release compile scripts, as well as CodeBlocks build environment for debug builds is included.
 
-#### Mining performance 
+#### Compile guides
+
+- [Windows](WINCOMPILE.md)
+
+#### Mining performance
 
 Mining core is a direct port (except for sercurity fixes) of wolf9466's AMD mining code. Performance is likely to be identical.
 
@@ -151,4 +155,3 @@ c4hC0Yg9Dha1OoE5CJCqVL+ic4vAyB1urAwBlsd/wH8=
 **msvcp140.dll and vcruntime140.dll not available errors**
 
 Download and install this [runtime package](https://www.microsoft.com/en-us/download/details.aspx?id=48145) from Microsoft.  *Warning: Do NOT use "missing dll" sites - dll's are exe files with another name, and it is a fairly safe bet that any dll on a shady site like that will be trojaned.  Please download offical runtimes from Microsoft above.*
-

--- a/WINCOMPILE.md
+++ b/WINCOMPILE.md
@@ -1,0 +1,80 @@
+# Compile **xmr-stak** for Windows
+
+## Install Dependencies
+
+### Preparation
+
+- open a command line `cmd`
+- run `mkdir C:\xmr-stak-dep`
+
+### Visual Studio 2017 Community
+
+- download VS2017 Community and install from [https://www.visualstudio.com/downloads/](https://www.visualstudio.com/downloads/)
+- during the install chose the components
+  - `Desktop development with C++` (left side)
+  - `Toolset for Visual Studio C++ 2015.3 v140...` (right side)
+
+### CMake for Win64
+
+- download and install the latest version from [https://cmake.org/download/](https://cmake.org/download/)
+- tested version: [cmake 3.9](https://cmake.org/files/v3.9/cmake-3.9.0-rc3-win64-x64.msi)
+- during the install choose the option `Add CMake to the system PATH for all users`
+
+### AMD APP SDK 3.0
+
+- download and install the latest version from [http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/](http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/)
+- tested version: AMD APP SDK 3.0
+
+### Dependencies OpenSSL/Hwloc and Microhttpd
+
+- download the precompiled binary from [https://github.com/fireice-uk/xmr-stak-dep/releases/download/v1/xmr-stak-dep.zip](https://github.com/fireice-uk/xmr-stak-dep/releases/download/v1/xmr-stak-dep.zip)
+- unzip all to `C:\xmr-stak-dep`
+
+### Validate the Dependency Folder
+
+- open a command line `cmd`
+- run
+   ```
+   cd c:\xmr-stak-dep
+   tree .
+   ```
+- the result should have the same structure
+  ```
+    C:\xmr-stak-dep>tree .
+    Folder PATH listing for volume Windows
+    Volume serial number is XX02-XXXX
+    C:\XMR-STAK-DEP
+    ├───hwloc
+    │   ├───include
+    │   │   ├───hwloc
+    │   │   │   └───autogen
+    │   │   └───private
+    │   │       └───autogen
+    │   └───lib
+    ├───libmicrohttpd
+    │   ├───include
+    │   └───lib
+    └───openssl
+        ├───bin
+        ├───include
+        │   └───openssl
+        └───lib
+  ```
+
+## Compile
+
+- download and unzip `xmr-stak-cpu`
+- open the command line terminal `cmd`
+- `cd` to your unzipped source code directory
+- execute the following commands (NOTE: path to VS2017 can be different)
+  ```
+  "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsMSBuildCmd.bat"
+  set CMAKE_PREFIX_PATH=C:\xmr-stak-dep\hwloc;C:\xmr-stak-dep\libmicrohttpd;C:\xmr-stak-dep\openssl
+  mkdir build
+  cd build
+  cmake -G "Visual Studio 15 2017 Win64" -T v141,host=x64 ..
+  msbuild xmr-stak-amd.sln /p:Configuration=Release
+  cd bin\Release
+  copy ..\..\..\config.txt .
+  ```
+- customize your `config.txt` file by adding the pool, username and password

--- a/WINCOMPILE.md
+++ b/WINCOMPILE.md
@@ -63,7 +63,7 @@
 
 ## Compile
 
-- download and unzip `xmr-stak-cpu`
+- download and unzip `xmr-stak-amd`
 - open the command line terminal `cmd`
 - `cd` to your unzipped source code directory
 - execute the following commands (NOTE: path to VS2017 can be different)


### PR DESCRIPTION
Fixed CMakeLists.txt for building on Windows - uses same "Find microhttpd" code as xmr-trak-cpu. Added Windows buid instructions and referenced them in README.