### PR TITLE
Don't buffer stdout for logs to appear immediately

### DIFF
--- a/cli-miner.cpp
+++ b/cli-miner.cpp
@@ -60,6 +60,7 @@ void do_benchmark();
 
 int main(int argc, char *argv[])
 {
+  setbuf(stdout, NULL);
 #ifndef CONF_NO_TLS
 	SSL_library_init();
 	SSL_load_error_strings();


### PR DESCRIPTION
Fixes bug https://github.com/fireice-uk/xmr-stak-amd/issues/86